### PR TITLE
Diff command output

### DIFF
--- a/lib/rspec/snapshot/matchers/match_snapshot.rb
+++ b/lib/rspec/snapshot/matchers/match_snapshot.rb
@@ -1,12 +1,16 @@
 require "fileutils"
+require "tempfile"
 
 module RSpec
   module Snapshot
     module Matchers
       class MatchSnapShot
+        @@diff_command_exists = nil
+
         def initialize(metadata, snapshot_name)
           @metadata = metadata
           @snapshot_name = snapshot_name
+          @@diff_command_exists = `diff --help &> /dev/null; echo $?`.to_i == 0 if @@diff_command_exists.nil?
         end
 
         def matches?(actual)
@@ -18,7 +22,16 @@ module RSpec
             file = File.new(snap_path)
             @expect = file.read
             file.close
-            @actual.to_s == @expect
+
+            match = @actual.to_s == @expect
+
+            if (@@diff_command_exists && !match)
+              @expected_temp_file = create_tempfile_with(@expect)
+              @actual_temp_file = create_tempfile_with(@actual)
+            end
+
+            match
+
           else
             RSpec.configuration.reporter.message "Generate #{snap_path}"
             file = File.new(snap_path, "w+")
@@ -28,9 +41,14 @@ module RSpec
           end
         end
 
-
         def failure_message
-          "\nexpected: #{@expect}\n     got: #{@actual}\n"
+          if @@diff_command_exists
+            message = `diff #{@expected_temp_file.path} #{@actual_temp_file.path}`
+            clean_up_temp_files
+            message
+          else
+            "\nexpected: #{@expect}\n     got: #{@actual}\n"
+          end
         end
 
         def snapshot_dir
@@ -40,6 +58,19 @@ module RSpec
             RSpec.configuration.snapshot_dir
           end
         end
+
+        private
+          def create_tempfile_with(content)
+            file = Tempfile.new('rspec-snapshot-tempfile')
+            file.write(content)
+            file.close
+            file
+          end
+
+          def clean_up_temp_files
+            @expected_temp_file.unlink
+            @actual_temp_file.unlink
+          end
       end
     end
   end

--- a/lib/rspec/snapshot/matchers/match_snapshot.rb
+++ b/lib/rspec/snapshot/matchers/match_snapshot.rb
@@ -24,14 +24,12 @@ module RSpec
             file.close
 
             match = @actual.to_s == @expect
-
             if (@@diff_command_exists && !match)
               @expected_temp_file = create_tempfile_with(@expect)
               @actual_temp_file = create_tempfile_with(@actual)
             end
 
             match
-
           else
             RSpec.configuration.reporter.message "Generate #{snap_path}"
             file = File.new(snap_path, "w+")


### PR DESCRIPTION
If the `diff` command is present, show the output of the diff command on temp files created from `@expect` and `@actual`, this makes troubleshooting failing snapshot tests much quicker.  The diff command should be present in most *nixes and OSX.  If the command is not present, it defaults to existing functionality.