### PR TITLE
Recommend using the snapshot_testing gem instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Adding snapshot testing to RSpec, inspired by [Jest](http://facebook.github.io/jest/blog/2016/07/27/jest-14.html).
 
+**Using the [`snapshot_testing` gem](https://github.com/rzane/snapshot_testing) is recommended instead.**
+
 ## Installation
 
 Add this line to your application's Gemfile:


### PR DESCRIPTION
When I was most of the way through making the changes in https://github.com/harrylewis/rspec-snapshot/pull/22, I realised it was taking more effort to fix up than the simple branch-merging fork I first thought it'd be. At that point, I had more of a look around for alternative gems - and found one: [`snapshot_testing`](https://github.com/rzane/snapshot_testing). It's more polished, has the snapshot update feature released, and is compatible with more test runners. But it doesn't show up on Google. All this combined with how `rspec-snapshot` is looking for a maintainer, and I thought I'd propose adding a link to that gem.