### PR TITLE
Add the ability to serialize snapshots as HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ Or install it yourself as:
 
     $ gem install rspec-snapshot
 
+## Optional peer dependency: htmlbeautifier
+
+By default, `rspec-snapshot` serializes string values as-is. If you want
+to serialize them as human-readable HTML, you can add `htmlbeautifier`
+to your gemfile and enable the relevant config options.
+
+You can also supply a different HTML serializer if you want. If you do
+that, you don't have to install `htmlbeautifier`.
+
 ## Usage
 
 The gem provides `match_snapshot` and `snapshot` RSpec matchers which take

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ a snapshot name as an argument like:
 # match_snapshot
 expect(generated_email).to match_snapshot('welcome_email')
 
+# match_snapshot with HTML serializer using the :html config option
+expect(html_response).to match_snapshot('html_response', { html: true })
+
 # match argument with snapshot
 expect(logger).to have_received(:info).with(snapshot('log message'))
 ```
@@ -95,19 +98,33 @@ RSpec.configure do |config|
   # created in a '__snapshots__' directory adjacent to the spec file where the
   # matcher is used.
   #
-  # Set this value to put all snapshots in a fixed directory
+  # Set this value to put all snapshots in a fixed directory.
   config.snapshot_dir = "spec/fixtures/snapshots"
 
-  # Defaults to using the awesome_print gem to serialize values for snapshots
+  # Defaults to using the htmlbeautifier gem to serialize html values for snapshots.
   #
-  # Set this value to use a custom snapshot serializer
+  # Set this value to use a custom snapshot serializer for html strings.
+  #
+  # You will also need to set `:html` in the example metadata,
+  # or enable the `snapshot_serialize_all_strings_as_html` config setting.
+  config.snapshot_html_serializer = MyFavoriteHtmlSerializer
+
+  # The default setting is to only serialize string values as HTML when `:html`
+  # is set on the example metadata.
+  #
+  # Set this value to `true` to serialize all string values as though they are HTML.
+  config.snapshot_serialize_all_strings_as_html = true
+
+  # Defaults to using the awesome_print gem to serialize non-string values for snapshots.
+  #
+  # Set this value to use a custom snapshot serializer.
   config.snapshot_serializer = MyFavoriteSerializer
 end
 ```
 
 ### Custom serializers
 
-By default, values to be stored as snapshots are serialized to human readable
+By default, non-string values to be stored as snapshots are serialized to human readable
 string form using the [awesome_print](https://github.com/awesome-print/awesome_print) gem.
 
 You can pass custom serializers to `rspec-snapshot` if you prefer. Pass a serializer class name to the global RSpec config, or to an individual
@@ -120,8 +137,29 @@ RSpec.configure do |config|
 end
 
 # Set a custom serializer for this specific test
+# Note: This does not apply if the value passed to `expect` is a string.
+expect(value).to(
+  match_snapshot('value', { snapshot_serializer: MyAwesomeValueSerializer })
+)
+```
+
+When `:html` is set on a test example's metadata, string values are serialized to human readable
+HTML using the [htmlbeautifier](https://github.com/threedaymonk/htmlbeautifier) gem.
+
+You can pass a custom HTML serializer as a class name to the global RSpec config, or to an individual matcher as a config option:
+
+```ruby
+# Set a custom HTML serializer for all tests
+RSpec.configure do |config|
+  config.snapshot_serializer = MyCoolGeneralHTMLSerializer
+end
+
+# Set a custom html serializer for this specific test.
+# This only applies if the value passed to `expect` is a string,
+# and either `:html` is set on the example metadata,
+# or the global `snapshot_serialize_all_strings_as_html` config option is enabled.
 expect(html_response).to(
-  match_snapshot('html_response', { snapshot_serializer: MyAwesomeHTMLSerializer })
+  match_snapshot('html_response', { snapshot_html_serializer: MyAwesomeHTMLSerializer })
 )
 ```
 

--- a/lib/rspec/snapshot/configuration.rb
+++ b/lib/rspec/snapshot/configuration.rb
@@ -10,6 +10,10 @@ module RSpec
     def self.initialize_configuration(config)
       config.add_setting :snapshot_dir, default: :relative
 
+      config.add_setting :snapshot_html_serializer, default: nil
+
+      config.add_setting :snapshot_serialize_all_strings_as_html, default: false
+
       config.add_setting :snapshot_serializer, default: nil
     end
 

--- a/lib/rspec/snapshot/default_html_serializer.rb
+++ b/lib/rspec/snapshot/default_html_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "htmlbeautifier"
+
+module RSpec
+  module Snapshot
+    class DefaultHtmlSerializer
+      def dump(value)
+        HtmlBeautifier.beautify(value)
+      end
+    end
+  end
+end

--- a/lib/rspec/snapshot/matchers/match_snapshot.rb
+++ b/lib/rspec/snapshot/matchers/match_snapshot.rb
@@ -16,7 +16,7 @@ module RSpec
           @snapshot_name = snapshot_name
           @config = config
           @serializer = serializer_class.new
-          @html_serializer = html_serializer_class.new
+          @html_serializer = html_serializer_class.new if use_html_serializer?
           @snapshot_path = File.join(snapshot_dir, "#{@snapshot_name}.snap")
           create_snapshot_dir
         end
@@ -70,7 +70,7 @@ module RSpec
 
         private def serialize(value)
           if value.is_a?(String)
-            if RSpec.configuration.snapshot_serialize_all_strings_as_html || @config[:html]
+            if use_html_serializer?
               @html_serializer.dump(value)
             else
               value
@@ -78,6 +78,10 @@ module RSpec
           else
             @serializer.dump(value)
           end
+        end
+
+        private def use_html_serializer?
+          RSpec.configuration.snapshot_serialize_all_strings_as_html || @config[:html]
         end
 
         private def write_snapshot

--- a/rspec-snapshot.gemspec
+++ b/rspec-snapshot.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'awesome_print', '> 1.0.0'
-  spec.add_dependency 'htmlbeautifier', '~> 1.3', '>= 1.3.1'
   spec.add_dependency 'rspec', '> 3.0.0'
 
   spec.add_development_dependency 'bundler', '~> 2.2'

--- a/rspec-snapshot.gemspec
+++ b/rspec-snapshot.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'awesome_print', '> 1.0.0'
+  spec.add_dependency 'htmlbeautifier', '~> 1.3', '>= 1.3.1'
   spec.add_dependency 'rspec', '> 3.0.0'
 
   spec.add_development_dependency 'bundler', '~> 2.2'


### PR DESCRIPTION
### Context

When receiving a string value to `expect`, the matcher assumed that it
was already in human-readable format and did not serialize it.

This was problematic for string-based HTML values, because it meant that
we couldn't serialize them, even when we passed in a custom serializer.

### Changes

This commit introduces the ability to serialize string values as HTML.

By default, it uses the `htmlbeautifier` gem.

The config options have been expanded to allow a different HTML
serializer at both a global and an example level. This follows the
existing config pattern defined by the serializer for non-string values.

### Considerations

There are legitimate use cases where a developer wants to compare
snapshots of non-HTML strings. It would therefore be unhelpful to
arbitrarily serialize every string value as though it is HTML.

On the other hand, some test suites might only use snapshot testing for
their HTML documents. When that's the case, it would be more convenient
to set a global config option than to specify `html: true` on every
`match_snapshot` call.

To make sure that we cover all possible use cases, I've opted to make
this feature as configurable as possible. The default configuration
keeps the behaviour of the previous version so that people updating the
gem don't see any unexpected snapshot failures.

### The build fails!

The build currently fails because I haven't updated the tests.

Since this feature wasn't requested, I thought it better to first find
out whether or not it is welcome. If it is, I'll go ahead and update the
tests so that the PR can be merged with a green build. 🙂