### PR TITLE
create sub snapshot folder if needed

### DIFF
--- a/lib/rspec/snapshot/file_operator.rb
+++ b/lib/rspec/snapshot/file_operator.rb
@@ -13,8 +13,8 @@ module RSpec
       # @param [Hash] metadata The RSpec metadata for the current test.
       def initialize(snapshot_name, metadata)
         snapshot_dir = snapshot_dir(metadata)
-        create_snapshot_dir(snapshot_dir)
         @snapshot_path = File.join(snapshot_dir, "#{snapshot_name}.snap")
+        create_snapshot_dir(@snapshot_path)
       end
 
       private def snapshot_dir(metadata)
@@ -26,7 +26,9 @@ module RSpec
       end
 
       private def create_snapshot_dir(snapshot_dir)
-        FileUtils.mkdir_p(snapshot_dir)
+        return if Dir.exist?(File.dirname(snapshot_dir))
+
+        FileUtils.mkdir_p(File.dirname(snapshot_dir))
       end
 
       # @return [String] The snapshot file contents.

--- a/spec/rspec/snapshot/file_operator_spec.rb
+++ b/spec/rspec/snapshot/file_operator_spec.rb
@@ -38,6 +38,9 @@ describe RSpec::Snapshot::FileOperator do
 
     context 'when RSpec is configured with a fixed snapshot directory' do
       let(:fixed_snapshot_dir) { 'spec/snapshots' }
+      let(:snapshot_name) do
+        'any_sub_folder/any_sub_sub_folder/descriptive_snapshot_name'
+      end
       let(:fixed_snapshot_path) do
         "#{fixed_snapshot_dir}/#{snapshot_name}.snap"
       end
@@ -51,7 +54,9 @@ describe RSpec::Snapshot::FileOperator do
 
       it 'creates the snapshot directory if needed' do
         expect(FileUtils).to(
-          have_received(:mkdir_p).with(fixed_snapshot_dir)
+          have_received(:mkdir_p).with(
+            "#{fixed_snapshot_dir}/any_sub_folder/any_sub_sub_folder"
+          )
         )
       end
 


### PR DESCRIPTION
Hi,

With the change in PR #41 the possibility to create any sub snapshot folder was removed.

See commit https://github.com/levinmr/rspec-snapshot/pull/41/files#diff-77a31662fea6835344c608536c400f703b46bab2949428eb582dc07538ee2752R29

This PR added the possibility again.